### PR TITLE
C interface

### DIFF
--- a/Dip/src/Decomp.h
+++ b/Dip/src/Decomp.h
@@ -206,11 +206,11 @@ const std::string DecompPriceCutStrategyStr[3] = {
 
 //===========================================================================//
 enum DecompSolverStatus {
-   DecompSolStatError,
-   DecompSolStatOptimal,
-   DecompSolStatFeasible,
-   DecompSolStatInfeasible,
-   DecompSolStatNoSolution
+   DecompSolStatError = -1,
+   DecompSolStatOptimal = 0,
+   DecompSolStatFeasible = 1,
+   DecompSolStatInfeasible = 2,
+   DecompSolStatNoSolution = 3
 };
 
 //===========================================================================//
@@ -268,9 +268,9 @@ const std::string DecompRowTypeStr[4] = {
 //Corresponding to the class DecompVar
 enum DecompVarType {
    // points generated from bounded subproblem
-   DecompVar_Point,
+   DecompVar_Point = 0,
    // rays generated from unbounded subproblem
-   DecompVar_Ray
+   DecompVar_Ray = 1
 };
 
 

--- a/Dip/src/DecompConstraintSet.h
+++ b/Dip/src/DecompConstraintSet.h
@@ -185,6 +185,24 @@ public:
       }
    }
 
+   inline void pushCol(const double loBound,
+                       const double upBound,
+                       std::string colName,
+                       const bool isInteger = false,
+                       const int origIndex = -1)
+   {
+      pushCol(loBound, upBound, isInteger, origIndex);
+      colNames.push_back(colName);
+   }
+
+   inline void init(const int nCols,
+                    const int nRows)
+   {
+      M = new CoinPackedMatrix(false, 0.0, 0.0);
+      M->setDimensions(0, nCols);
+      reserve(nCols, nRows);
+   }
+
    inline void reserve(const int nCols,
                        const int nRows) {
       M->reserve(nRows, nCols);

--- a/Dip/src/Decomp_C_Interface.cpp
+++ b/Dip/src/Decomp_C_Interface.cpp
@@ -1,0 +1,171 @@
+#include "Decomp_C_Interface.h"
+#include "DecompApp.h"
+#include "AlpsDecompModel.h"
+#include "DecompAlgoC.h"
+#include "DecompAlgoPC.h"
+
+extern "C"
+{
+    //===========================================================================//
+    // UtilParameters
+    //===========================================================================//
+    UtilParameters *Dip_UtilParameters_new()
+    {
+        return new UtilParameters();
+    }
+
+    void Dip_UtilParameters_delete(UtilParameters *utilParams)
+    {
+        if (utilParams)
+            delete utilParams;
+    }
+
+    void Dip_UtilParameters_ScanCmdLineArgs(UtilParameters *utilParams,
+                                            int argc,
+                                            char *argv[])
+    {
+        utilParams->ScanCmdLineArgs(argc, argv);
+    }
+
+    int Dip_UtilParameters_getSetting(UtilParameters *utilParams,
+                                      const char *name,
+                                      const int defaultValue,
+                                      const char *section)
+    {
+        return utilParams->GetSetting(name, defaultValue, section);
+    }
+
+    //===========================================================================//
+    // DecompApp
+    //===========================================================================//
+    DecompApp *Dip_DecompApp_new(UtilParameters *utilParams)
+    {
+        return new DecompApp(*utilParams);
+    }
+
+    void Dip_DecompApp_delete(DecompApp *app)
+    {
+        if (app)
+            delete app;
+    }
+
+    void Dip_DecompApp_setModelObjective(DecompApp *app, const double *objective, const int length)
+    {
+        app->setModelObjective(objective, length);
+    }
+
+    void Dip_DecompApp_setModelCore(DecompApp *app, DecompConstraintSet *model,
+                                    const char *modelName)
+    {
+        std::string s(modelName);
+        app->setModelCore(model, s);
+    }
+
+    void Dip_DecompApp_setModelRelax(DecompApp *app,
+                                     DecompConstraintSet *model,
+                                     const char *modelName,
+                                     const int blockId)
+    {
+        std::string s(modelName);
+        app->setModelRelax(model, s, blockId);
+    }
+
+    double Dip_DecompApp_getInfinity(DecompApp *app)
+    {
+        return app->m_infinity;
+    }
+
+    //===========================================================================//
+    // DecompConstraintSet
+    //===========================================================================//
+    DecompConstraintSet *Dip_DecompConstraintSet_new()
+    {
+        return new DecompConstraintSet();
+    }
+    void Dip_DecompConstraintSet_delete(DecompConstraintSet *constrSet)
+    {
+        if (constrSet)
+            delete constrSet;
+    }
+    void Dip_DecompConstraintSet_init(DecompConstraintSet *constrSet, const int nCols, const int nRows)
+    {
+        constrSet->init(nCols, nRows);
+    }
+    void Dip_DecompConstraintSet_appendRow(DecompConstraintSet *constrSet, int size, const int *inds, const double *elems,
+                                           double loBound,
+                                           double upBound,
+                                           const char *rowName)
+    {
+        CoinPackedVector row(size, inds, elems);
+        std::string s(rowName);
+        constrSet->appendRow(row, loBound, upBound, s);
+    }
+    void Dip_DecompConstraintSet_pushCol(DecompConstraintSet *constrSet, const double loBound,
+                                         const double upBound,
+                                         const char *colName,
+                                         const int isInteger,
+                                         const int origIndex)
+    {
+        std::string s(colName);
+        constrSet->pushCol(loBound, upBound, s, isInteger, origIndex);
+    }
+    void Dip_DecompConstraintSet_setSparse(DecompConstraintSet *constrSet, const int numColsOrig)
+    {
+        constrSet->setSparse(numColsOrig);
+    }
+
+    //===========================================================================//
+    // DecompAlgo
+    //===========================================================================//
+    DecompAlgo *Dip_DecompAlgoC_new(DecompApp *app, UtilParameters *utilParam)
+    {
+        return new DecompAlgoC(app, *utilParam);
+    }
+    DecompAlgo *Dip_DecompAlgoPC_new(DecompApp *app, UtilParameters *utilParam)
+    {
+        return new DecompAlgoPC(app, *utilParam);
+    }
+    void Dip_DecompAlgo_delete(DecompAlgo *algo)
+    {
+        if (algo)
+            delete algo;
+    }
+
+    //===========================================================================//
+    // AlpsDecompModel
+    //===========================================================================//
+    AlpsDecompModel *Dip_AlpsDecompModel_new(UtilParameters *utilParam, DecompAlgo *algo)
+    {
+        return new AlpsDecompModel(*utilParam, algo);
+    }
+    void Dip_AlpsDecompModel_delete(AlpsDecompModel *alps)
+    {
+        if (alps)
+            delete alps;
+    }
+    int Dip_AlpsDecompModel_solve(AlpsDecompModel *alps)
+    {
+        FILE *fp = fopen("master.lp", "w");
+        alps->getDecompAlgo()->getMasterOSI()->writeLp(fp);
+        AlpsExitStatus status = alps->solve();
+        return status;
+    }
+
+    //===========================================================================//
+    // DecompVar
+    //===========================================================================//
+    DecompVar *Dip_DecompVar_new(const int len,
+                                 const int *ind,
+                                 const double *els,
+                                 const double redCost,
+                                 const double origCost,
+                                 const int varType)
+    {
+        return new DecompVar(len, ind, els, redCost, origCost, (DecompVarType)varType);
+    }
+
+    void Dip_DecompVar_delete(DecompVar *var)
+    {
+        delete var;
+    }
+}

--- a/Dip/src/Decomp_C_Interface.h
+++ b/Dip/src/Decomp_C_Interface.h
@@ -1,0 +1,87 @@
+#ifndef DECOMP_C_INTERFACE_INCLUDED
+#define DECOMP_C_INTERFACE_INCLUDED
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    typedef struct UtilParameters UtilParameters;
+    typedef struct DecompApp DecompApp;
+    typedef struct DecompConstraintSet DecompConstraintSet;
+    typedef struct DecompAlgo DecompAlgo;
+    typedef struct AlpsDecompModel AlpsDecompModel;
+    typedef struct DecompVar DecompVar;
+
+    //===========================================================================//
+    // UtilParameters
+    //===========================================================================//
+    UtilParameters *Dip_UtilParameters_new();
+    void Dip_UtilParameters_delete(UtilParameters *utilParams);
+    void Dip_UtilParameters_ScanCmdLineArgs(UtilParameters *utilParams,
+                                            int argc,
+                                            char *argv[]);
+    int Dip_UtilParameters_getSetting(UtilParameters *utilParams,
+                                      const char *name,
+                                      const int defaultValue,
+                                      const char *section);
+
+    //===========================================================================//
+    // DecompApp
+    //===========================================================================//
+    DecompApp *Dip_DecompApp_new(UtilParameters *utilParams);
+    void Dip_DecompApp_delete(DecompApp *app);
+    void Dip_DecompApp_setModelObjective(DecompApp *app, const double *objective, const int length);
+    void Dip_DecompApp_setModelCore(DecompApp *app, DecompConstraintSet *model,
+                                    const char *modelName);
+    void Dip_DecompApp_setModelRelax(DecompApp *app,
+                                     DecompConstraintSet *model,
+                                     const char *modelName,
+                                     const int blockId);
+    double Dip_DecompApp_getInfinity(DecompApp *app);
+
+    //===========================================================================//
+    // DecompConstraintSet
+    //===========================================================================//
+    DecompConstraintSet *Dip_DecompConstraintSet_new();
+    void Dip_DecompConstraintSet_delete(DecompConstraintSet *constrSet);
+    void Dip_DecompConstraintSet_init(DecompConstraintSet *constrSet, const int nCols, const int nRows);
+    void Dip_DecompConstraintSet_appendRow(DecompConstraintSet *constrSet, int size, const int *inds, const double *elems,
+                                           double loBound,
+                                           double upBound,
+                                           const char *rowName);
+    void Dip_DecompConstraintSet_pushCol(DecompConstraintSet *constrSet, const double loBound,
+                                         const double upBound,
+                                         const char *colName,
+                                         const int isInteger,
+                                         const int origIndex);
+    void Dip_DecompConstraintSet_setSparse(DecompConstraintSet *constrSet, const int numColsOrig);
+
+    //===========================================================================//
+    // DecompAlgo
+    //===========================================================================//
+    DecompAlgo *Dip_DecompAlgoC_new(DecompApp *app, UtilParameters *utilParam);
+    DecompAlgo *Dip_DecompAlgoPC_new(DecompApp *app, UtilParameters *utilParam);
+    void Dip_DecompAlgo_delete(DecompAlgo *algo);
+
+    //===========================================================================//
+    // AlpsDecompModel
+    //===========================================================================//
+    AlpsDecompModel *Dip_AlpsDecompModel_new(UtilParameters *utilParam, DecompAlgo *algo);
+    void Dip_AlpsDecompModel_delete(AlpsDecompModel *alps);
+    int Dip_AlpsDecompModel_solve(AlpsDecompModel *alps);
+
+    //===========================================================================//
+    // DecompVar
+    //===========================================================================//
+    DecompVar *Dip_DecompVar_new(const int len,
+                                 const int *ind,
+                                 const double *els,
+                                 const double redCost,
+                                 const double origCost,
+                                 const int varType);
+    void Dip_DecompVar_delete(DecompVar *var);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/Dip/src/Makefile.in
+++ b/Dip/src/Makefile.in
@@ -89,7 +89,7 @@ am_libDecomp_la_OBJECTS = DecompAlgo.lo DecompAlgoC.lo DecompAlgoD.lo \
 	DecompConstraintSet.lo UtilGraphLib.lo UtilHash.lo \
 	UtilMacros.lo UtilMacrosDecomp.lo UtilParameters.lo \
 	UtilKnapsack.lo AlpsDecompModel.lo AlpsDecompTreeNode.lo \
-	UtilMacrosAlps.lo
+	UtilMacrosAlps.lo Decomp_C_Interface.lo
 libDecomp_la_OBJECTS = $(am_libDecomp_la_OBJECTS)
 binPROGRAMS_INSTALL = $(INSTALL_PROGRAM)
 PROGRAMS = $(bin_PROGRAMS)
@@ -435,7 +435,7 @@ libDecomp_la_SOURCES = DecompAlgo.cpp DecompAlgo.h DecompAlgoC.cpp \
 	AlpsDecompModel.cpp AlpsDecompModel.h AlpsDecompSolution.h \
 	AlpsDecompTreeNode.cpp AlpsDecompTreeNode.h \
 	AlpsDecompNodeDesc.h AlpsDecompParam.h UtilMacrosAlps.cpp \
-	UtilMacrosAlps.h
+	UtilMacrosAlps.h Decomp_C_Interface.h Decomp_C_Interface.cpp
 
 # List all additionally required libraries
 @DEPENDENCY_LINKING_TRUE@libDecomp_la_LIBADD = $(DIPLIB_LIBS) $(DIP_OPENMP_LIBS)
@@ -484,7 +484,8 @@ includecoin_HEADERS = DecompAlgo.h DecompAlgoC.h DecompAlgoD.h \
 	DecompWaitingRow.h UtilGraphLib.h UtilHash.h UtilMacros.h \
 	UtilMacrosDecomp.h UtilParameters.h UtilKnapsack.h UtilTimer.h \
 	AlpsDecompModel.h AlpsDecompSolution.h AlpsDecompTreeNode.h \
-	AlpsDecompNodeDesc.h AlpsDecompParam.h UtilMacrosAlps.h
+	AlpsDecompNodeDesc.h AlpsDecompParam.h UtilMacrosAlps.h \
+	Decomp_C_Interface.h
 all: config.h config_dip.h
 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
 
@@ -639,6 +640,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/UtilMacrosAlps.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/UtilMacrosDecomp.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/UtilParameters.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/Decomp_C_Interface.Plo@am__quote@
 
 .cpp.o:
 @am__fastdepCXX_TRUE@	if $(CXXCOMPILE) -MT $@ -MD -MP -MF "$(DEPDIR)/$*.Tpo" -c -o $@ $<; \


### PR DESCRIPTION
This is a suggestion for a minimum C interface for using Dip. This allows easy integration with other languages etc.

Then the user can do:
```c
int main(int argc, char *argv[])
{
        struct UtilParameters *utilParam = Dip_UtilParameters_new();
        Dip_UtilParameters_ScanCmdLineArgs(utilParam, argc, argv);
        struct DecompApp *app = Dip_DecompApp_new(utilParam);

        int numCols = 100;
        int numRows = 100;

        // objective
        double objective[numCols]; 
        // ... set objective
        Dip_DecompApp_setModelObjective(app, objective, numCols);

        // models
        DecompConstraintSet *modelCore = Dip_DecompConstraintSet_new();
        Dip_DecompConstraintSet_init(modelCore, numCols, numRows);

        // put rows in model
        // Dip_DecompConstraintSet_appendRow(modelRelaxed, size, inds, elems, lb, ub, "rowName");

        Dip_DecompApp_setModelCore(app, modelCore, "modelCore");

        // same for relaxed problems
        // Dip_DecompApp_setModelRelax(app, modelRelaxed, string, k);

        DecompAlgo* algo = Dip_DecompAlgoPC_new(app, utilParam);
        Dip_DecompApp_setCallbackSolveRelaxed(app, callback_SolvedRelaxed);

        AlpsDecompModel *alps = Dip_AlpsDecompModel_new(utilParam, algo);
        int status = Dip_AlpsDecompModel_solve(alps);
}
```

This was the easy option using the current classes and way of setting stuff up. My idea was just to expand the interface when needed but keeping it a very thin wrapper.

Some thoughts:
1. Should Dip maybe implement OsiSolverInterface? And should that be the one that is wrapped? This would allow a common interface for adding vars and rows. It should be extended to specify what vars/rows goto what blocks when using PC algo.
2. I named the files Dip_*. I am thinking that the other files should also be renamed from Decomp* to Dip* at some point? But perhaps Decomp* is also better for the C interface at the time?