### PR TITLE
Callbacks take 1

### DIFF
--- a/Dip/src/DecompApp.cpp
+++ b/Dip/src/DecompApp.cpp
@@ -85,20 +85,6 @@ int DecompApp::generateInitVars(DecompVarList& initVars)
    return 0;
 }
 
-// --------------------------------------------------------------------- //
-int DecompApp::generateCuts(const double*   x,
-                            DecompCutList& newCuts)
-{
-   // ---
-   // --- this function does nothing by default
-   // ---
-   UtilPrintFuncBegin(m_osLog, m_classTag,
-                      "generateCuts()", m_param.LogDebugLevel, 2);
-   UtilPrintFuncEnd(m_osLog, m_classTag,
-                    "generateCuts()", m_param.LogDebugLevel, 2);
-   return 0;
-}
-
 /*-------------------------------------------------------------------------*/
 void DecompApp::printOriginalColumn(const int index,
                                     ostream* os) const


### PR DESCRIPTION
A simple solution to how callback functions can be used in `DecompApp`.

This approach uses `std::function` and sets them directly per method that can do callback. The example is for cuts and solving the relaxations. There can only be one method assigned per callback so multiple cut generators or pricing algorithms must be handled by the one callback being set.

I am not entirely happy with the approach since you have to make a new setter for each type of callback. 

Also, a thing with `std::function` and setting member functions has by using `std::bind`:
```c
      CallbackClass c;
      app->setCallbackSolveRelaxed(std::bind(&CallbackClass::CallbackMemberFn, &c, 
             std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, 
             std::placeholders::_4, std::placeholders::_5);
```
not the cleanest approach, but doable.

Alternative solutions are 
- one callback to do everything (Gurobi style), then user has to know what to do based on a `where` argument.
- inherit from a callback class and implement method, then feed callback object to setter (Cplex style). Almost as cumbersome as current solution with inheritance of `DecompApp`. Less flexible for prototyping where on wants to add global functions fast.

@tkralphs any thoughts one how to approach this?