### PR TITLE
remove assert

### DIFF
--- a/Dip/src/DecompAlgo.cpp
+++ b/Dip/src/DecompAlgo.cpp
@@ -798,7 +798,6 @@ void DecompAlgo::createMasterProblem(DecompVarList& initVars)
    int nRowsCore = modelCore->getNumRows();
    int nIntVars  = modelCore->getNumInts();
    int nInitVars = static_cast<int>(initVars.size());
-   assert(initVars.size() > 0);//TODO: this should be OK
    double* dblArrNCoreCols = new double[nColsCore];
    assert(dblArrNCoreCols);
    //---


### PR DESCRIPTION
The assert checks for initial variables and fails in debug mode if no variables are present.
It is OK to have no variables - it is an unnecessary check. The master restores feasibility using artificial variables.

It stalled on the macOS 9.2 build. Timeout? I have no idea why it did not succeed.