### PR TITLE
Update stable ci for win and linux for deprecated and new OS

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         build_static: [true, false]
-        download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
+        download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
           - os: macos-13
             build_static: false

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -21,8 +21,9 @@ jobs:
       matrix:
         include: [
           { os: windows-2022, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
-          { os: windows-2022, arch: x86_64, msystem: mingw64, debug: false, suffix: "" },
-          { os: windows-2022, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
+          { os: windows-2025, arch: x86_64, msystem: mingw64, debug: false, suffix: "" },
+          { os: windows-2022, arch: msvc, msystem: mingw64, debug: true, suffix: "-dbg" },
+          { os: windows-2025, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
         ]
     steps:
       - name: Checkout source

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -59,7 +59,7 @@ jobs:
           ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )
           ADD_BUILD_ARGS=()
           ADD_BUILD_ARGS+=( --build=x86_64-w64-mingw32 --tests main --enable-relocatable --disable-pkg-config )
-          ADD_BUILD_ARGS+=( --verbosity 2 )
+          ADD_BUILD_ARGS+=( --disable-openmp --verbosity 2 )
           [[ ${{ matrix.debug }} == "true" ]] && ADD_BUILD_ARGS+=( --enable-debug )
           [[ ${{ matrix.arch }} == "msvc" ]] && ADD_BUILD_ARGS+=( --enable-msvc=MD )
           ./coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update "${ADD_ARGS[@]}"


### PR DESCRIPTION
For stable branch.
See also COIN-OR-OptimizationSuite [Issue 32](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/32) and [Issue 33](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/33):

Remove Windows Server 2019 runner images for Actions are being deprecated in June 2025.
Add tests for the new Windows Server 2025 which was released Nov 2024.
Similarly, remove deprecated Ubuntu 20.04 and add new Ubuntu 24.04.
These changes are done for all ci workflows.